### PR TITLE
Auto focus inputs

### DIFF
--- a/tfdpreplan/forms.py
+++ b/tfdpreplan/forms.py
@@ -8,14 +8,15 @@ from .utils import normalize_street_type
 
 
 class AddressForm(forms.Form):
-    street_no = forms.IntegerField(min_value=0)
-    street_dir = forms.RegexField(regex=r'^[NORnorSOUsouTHthEAeaWEweSTst]+$', min_length=1, error_message="Not a valid direction, check your spelling.")
-    street_name = forms.RegexField(regex=r'^[\w+ \'&\.]+', min_length=1, error_message="Not a valid street name.  Check for special characters.")
-    street_type = forms.RegexField(regex=r'^[\w+]+', min_length=1, error_message="Not a valid street type.  Check for special characters.")
+    street_no = forms.IntegerField(min_value=0, widget=forms.TextInput(attrs={"size":"7"}))
+    street_dir = forms.RegexField(regex=r'^[\w]+$', max_length=5, widget=forms.TextInput(attrs={"size":"5"}))
+    street_name = forms.RegexField(regex=r'^[\w+ \'&\.]+', min_length=1)
+    street_type = forms.RegexField(regex=r'^[\w+]+', min_length=1, widget=forms.TextInput(attrs={"size":"5"}))
 
 
     def clean_address(self):
-        self.cleaned_data['address'] = "%d %s %s %s".format(self.cleaned_data['street_no'], self.cleaned_data['street_dir'], self.cleaned_data['street_name'], self.cleaned_data['street_type'])
+        # import ipdb; ipdb.set_trace()
+        self.cleaned_data['address'] = "%d %s %s %s" % (self.cleaned_data['street_no'], self.cleaned_data['street_dir'], self.cleaned_data['street_name'], self.cleaned_data['street_type'])
 
         parser = StreetAddressParser()
         parts = parser.parse(self.cleaned_data['address'])

--- a/tfdpreplan/forms.py
+++ b/tfdpreplan/forms.py
@@ -8,9 +8,15 @@ from .utils import normalize_street_type
 
 
 class AddressForm(forms.Form):
-    address = forms.CharField(max_length=255)
+    street_no = forms.IntegerField(min_value=0)
+    street_dir = forms.RegexField(regex=r'^[NORnorSOUsouTHthEAeaWEweSTst]+$', min_length=1, error_message="Not a valid direction, check your spelling.")
+    street_name = forms.RegexField(regex=r'^[\w+ \'&\.]+', min_length=1, error_message="Not a valid street name.  Check for special characters.")
+    street_type = forms.RegexField(regex=r'^[\w+]+', min_length=1, error_message="Not a valid street type.  Check for special characters.")
+
 
     def clean_address(self):
+        self.cleaned_data['address'] = "%d %s %s %s".format(self.cleaned_data['street_no'], self.cleaned_data['street_dir'], self.cleaned_data['street_name'], self.cleaned_data['street_type'])
+
         parser = StreetAddressParser()
         parts = parser.parse(self.cleaned_data['address'])
         street_dir, street_name = parts['street_name'].split(' ', 1)
@@ -19,4 +25,3 @@ class AddressForm(forms.Form):
         self.cleaned_data['street_name'] = street_name
         self.cleaned_data['street_type'] = normalize_street_type(parts['street_type'])
         return self.cleaned_data['address']
-

--- a/tfdpreplan/static/js/prevalidate.js
+++ b/tfdpreplan/static/js/prevalidate.js
@@ -1,0 +1,55 @@
+function onKeyDownFilter(event, re, next, spaceAllowedFor) {
+    var keyCode = event.keyCode ? event.keyCode : event.which;
+    switch (keyCode) {
+        case 8:  // Backspace
+        case 9:  // Tab
+        case 13: // Enter
+        case 37: // Left
+        case 38: // Up
+        case 39: // Right
+        case 40: // Down
+            break;
+        case 32: // Space
+            if(spaceAllowedFor) {
+                var currentInput = $(spaceAllowedFor).val();
+
+                if(currentInput.substr(currentInput.length - 1) !== ' ') {
+                    return true;
+                }
+            }
+
+            $(next).focus();
+            event.preventDefault();
+            return false;
+
+            break;
+        default:
+            console.log(keyCode);
+            var regex = new RegExp(re);
+            var key = event.key;
+            if (!regex.test(key)) {
+                event.preventDefault();
+                return false;
+            }
+            break;
+    }
+}
+
+$().ready(function() {
+// validate signup form on keyup and submit
+    $('#id_street_no').on('keydown', function (event) {
+        onKeyDownFilter(event, "^[0-9]+$", "#id_street_dir", false);
+    });
+
+    $('#id_street_dir').on('keydown', function (event) {
+        onKeyDownFilter(event, "^[NORnorSUuTHthEAeaWwSTst]+$", "#id_street_name", false);
+    });
+
+    $('#id_street_name').on('keydown', function (event) {
+        onKeyDownFilter(event, "^[0-9a-zA-Z &\,\.\']+$", "#id_street_type", "#id_street_name");
+    });
+
+    $('#id_street_type').on('keydown', function (event) {
+        onKeyDownFilter(event, "^[0-9a-zA-Z]+$", "#id_street_nbr", false);
+    });
+});

--- a/tfdpreplan/templates/address_lookup.html
+++ b/tfdpreplan/templates/address_lookup.html
@@ -16,8 +16,10 @@
     </ul>
     <div class="tab-content">
         <div id="search" class="tab-pane fade in active">
-            <form action="{% url 'address_lookup'%}" method="post">
-            {{form.as_p}}
+            <form action="{% url 'address_lookup'%}" method="post" id="search-form">
+                <ul class="list-inline">
+                    {{form.as_ul}}
+                </ul>
             {% csrf_token %}
             <button type="submit">Lookup address</button>
             </form>
@@ -63,5 +65,8 @@
     </div>
 </div>
 
+{% endblock %}
 
+{% block scripts %}
+<script type="text/javascript" src="{% static '/js/prevalidate.js' %}"></script>
 {% endblock %}

--- a/tfdpreplan/templates/base.html
+++ b/tfdpreplan/templates/base.html
@@ -15,5 +15,7 @@
 
         <script src="{% static "/js/jquery.min.js" %}"></script>
         <script src="{% static "/js/bootstrap.min.js" %}"></script>
+
+        {% block scripts %}{% endblock %}
     </body>
 </html>

--- a/tfdpreplan/views.py
+++ b/tfdpreplan/views.py
@@ -14,6 +14,8 @@ class AddressLookupView(FormView):
     form_class = AddressForm
 
     def form_valid(self, form):
+        form.clean_address()
+
         data = get_property_data(
             form.cleaned_data['street_no'], form.cleaned_data['street_dir'],
             form.cleaned_data['street_name'], form.cleaned_data['street_type'])


### PR DESCRIPTION
You guys certainly don't have to accept this.  Andy was saying that if the input wasn't going to allow double spaces, missing pieces, etc, it should be separate boxes.  This patch splits up the address box into separate input which change focus with the space bar.  The "Street Name" field allows spaces, so to focus out of that, you hit the space bar twice.