### PR TITLE
Add map and sattelite to lookup 

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -1,0 +1,1 @@
+MAPBOX_TOKEN = "put-token-here"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 *.iml
 .idea/
 staticfiles
+.env

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 Django==1.10.6
 dj-static==0.0.6
 gunicorn==19.7.0
+mapbox==0.11.0
+python-decouple==3.0
 pyquery==1.2.17
 requests==2.13.0
 six==1.10.0

--- a/tfdpreplan/settings.py
+++ b/tfdpreplan/settings.py
@@ -11,6 +11,8 @@ https://docs.djangoproject.com/en/1.10/ref/settings/
 """
 
 import os
+from decouple import config
+
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR =  os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -131,3 +133,7 @@ STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
 )
+
+
+# MAPBOX
+MAPBOX_TOKEN = config('MAPBOX_TOKEN')

--- a/tfdpreplan/templates/address_lookup.html
+++ b/tfdpreplan/templates/address_lookup.html
@@ -12,8 +12,8 @@
         {% if property %}
         <li><a data-toggle="pill" href="#crits">Critical Info</a></li>
         <li><a data-toggle="pill" href="#images">Images</a></li>
-        <li><a data-toggle="pill" href="#map">Map</a></li>
-        <li><a data-toggle="pill" href="#satellite">Satellite</a></li>
+        <li><a data-toggle="pill" href="#map_pane">Map</a></li>
+        <li><a data-toggle="pill" href="#satellite_pane">Satellite</a></li>
         {% endif %}
     </ul>
     <div class="tab-content">
@@ -55,12 +55,11 @@
                 {% endfor %}
             </ul>
         </div>
-
-        <div id="map" class="tab-pane fade">
-            <a target="_blank" href="{{map_url}}">Google Maps Link</a>
+        <div id="map_pane" class="tab-pane fade">
+            {% include "includes/map.html" %}
         </div>
-        <div id="satellite" class="tab-pane fade">
-            <a target="_blank" href="{{map_url}}">Google Maps Link</a>
+        <div id="satellite_pane" class="tab-pane fade">
+            {% include "includes/satellite.html" %}
         </div>
         {% endif %}
     </div>

--- a/tfdpreplan/templates/base.html
+++ b/tfdpreplan/templates/base.html
@@ -8,6 +8,12 @@
         <title>TFD Preplan</title>
         <!-- Bootstrap -->
         <link href="{% static "css/bootstrap.min.css" %}" rel="stylesheet">
+
+        {# Mapbox #}
+        <script src='https://api.mapbox.com/mapbox-gl-js/v0.32.1/mapbox-gl.js'></script>
+        <link href='https://api.mapbox.com/mapbox-gl-js/v0.32.1/mapbox-gl.css' rel='stylesheet' />
+
+
     </head>
     <body>
 

--- a/tfdpreplan/templates/includes/map.html
+++ b/tfdpreplan/templates/includes/map.html
@@ -1,11 +1,13 @@
 
 <div id='map' style='width: 400px; height: 300px;'></div>
+
+
 <script>
-    mapboxgl.accessToken = 'pk.eyJ1IjoiamR1bmdhbiIsImEiOiJlOTl6MFpNIn0.-3o5vIOCjkfXd-7ibZrb8A';
+    mapboxgl.accessToken = '{{MAPBOX_TOKEN}}'
     var map = new mapboxgl.Map({
         container: 'map',
         style: 'mapbox://styles/mapbox/streets-v9',
-        center: [-95.993697,36.159097],
+        center: {{coordinates}},
         zoom: 17
     });
 </script>

--- a/tfdpreplan/templates/includes/map.html
+++ b/tfdpreplan/templates/includes/map.html
@@ -1,0 +1,11 @@
+
+<div id='map' style='width: 400px; height: 300px;'></div>
+<script>
+    mapboxgl.accessToken = 'pk.eyJ1IjoiamR1bmdhbiIsImEiOiJlOTl6MFpNIn0.-3o5vIOCjkfXd-7ibZrb8A';
+    var map = new mapboxgl.Map({
+        container: 'map',
+        style: 'mapbox://styles/mapbox/streets-v9',
+        center: [-95.993697,36.159097],
+        zoom: 17
+    });
+</script>

--- a/tfdpreplan/templates/includes/satellite.html
+++ b/tfdpreplan/templates/includes/satellite.html
@@ -1,11 +1,11 @@
 
 <div id='satellite' style='width: 400px; height: 300px;'></div>
 <script>
-    mapboxgl.accessToken = 'pk.eyJ1IjoiamR1bmdhbiIsImEiOiJlOTl6MFpNIn0.-3o5vIOCjkfXd-7ibZrb8A';
+    mapboxgl.accessToken = '{{MAPBOX_TOKEN}}'
     var map = new mapboxgl.Map({
         container: 'satellite',
         style: 'mapbox://styles/mapbox/satellite-v9',
-        center: [-95.993697,36.159097],
+        center: {{coordinates}},
         zoom: 17
     });
 </script>

--- a/tfdpreplan/templates/includes/satellite.html
+++ b/tfdpreplan/templates/includes/satellite.html
@@ -1,0 +1,11 @@
+
+<div id='satellite' style='width: 400px; height: 300px;'></div>
+<script>
+    mapboxgl.accessToken = 'pk.eyJ1IjoiamR1bmdhbiIsImEiOiJlOTl6MFpNIn0.-3o5vIOCjkfXd-7ibZrb8A';
+    var map = new mapboxgl.Map({
+        container: 'satellite',
+        style: 'mapbox://styles/mapbox/satellite-v9',
+        center: [-95.993697,36.159097],
+        zoom: 17
+    });
+</script>

--- a/tfdpreplan/tfd_geocoder.py
+++ b/tfdpreplan/tfd_geocoder.py
@@ -1,0 +1,12 @@
+from mapbox import Geocoder
+from settings import MAPBOX_TOKEN
+
+geocoder = Geocoder(access_token=MAPBOX_TOKEN)
+
+def getCoordinates(steet_address):
+
+    response = geocoder.forward(steet_address)
+
+    first = response.geojson()['features'][0]
+
+    return first['geometry']['coordinates']

--- a/tfdpreplan/tfd_geocoder.py
+++ b/tfdpreplan/tfd_geocoder.py
@@ -1,7 +1,12 @@
+import HTMLParser
+import requests
+
 from mapbox import Geocoder
 from settings import MAPBOX_TOKEN
 
 geocoder = Geocoder(access_token=MAPBOX_TOKEN)
+
+mapbox_url = "https://api.mapbox.com/v4"
 
 def getCoordinates(steet_address):
 
@@ -10,3 +15,17 @@ def getCoordinates(steet_address):
     first = response.geojson()['features'][0]
 
     return first['geometry']['coordinates']
+
+
+def getSlippyMap(street_address):
+    map_id = 'mapbox.light'
+    options = 'zoomwheel,zoompan'
+    zoom = 15
+    coords = getCoordinates(street_address)
+    # hash #{zoom}/{lat}/{lon}
+    hash = '%s/%s/%s' % (zoom, coords[1],coords[0])
+    request_url = '%s/%s/%s.html?access_token=%s&#%s' % (
+        mapbox_url, map_id, options, MAPBOX_TOKEN, hash
+    )
+    map_html = requests.get(request_url)
+    return map_html.text

--- a/tfdpreplan/urls.py
+++ b/tfdpreplan/urls.py
@@ -20,5 +20,9 @@ from . import views
 urlpatterns = [
     url(r'^$', views.Home.as_view(), name='home'),
     url(r'^admin/', admin.site.urls),
-    url(r'^lookup$', views.AddressLookupView.as_view(), name='address_lookup'),
+    url(r'^lookup$', views.AddressLookupView.as_view(),
+        name='address_lookup'),
+    url(r'^map/(?P<address>[^/.]+)',
+        views.StreetMap.as_view(), name='street-map'),
+
 ]

--- a/tfdpreplan/views.py
+++ b/tfdpreplan/views.py
@@ -5,6 +5,8 @@ from .forms import AddressForm
 from .utils import get_property_data
 from urllib import urlencode
 
+from  .tfd_geocoder import getCoordinates
+
 class Home(TemplateView):
     template_name = 'home.html'
 
@@ -19,5 +21,13 @@ class AddressLookupView(FormView):
         data = get_property_data(
             form.cleaned_data['street_no'], form.cleaned_data['street_dir'],
             form.cleaned_data['street_name'], form.cleaned_data['street_type'])
-        parsed_url = 'https://maps.google.com/?' + urlencode({'q': form.cleaned_data['address'] + ' Tulsa OK'})
-        return self.render_to_response(self.get_context_data(form=form, property=data, map_url=parsed_url))
+
+
+        coordinates = getCoordinates(form.cleaned_data['address'])
+        import ipdb; ipdb.set_trace()
+
+        return self.render_to_response(
+            self.get_context_data(
+                form=form, property=data, coordinates=coordinates
+            )
+        )

--- a/tfdpreplan/views.py
+++ b/tfdpreplan/views.py
@@ -1,9 +1,13 @@
 from django.views.generic import FormView, TemplateView
 from django.conf import settings
+from django.http import HttpResponse
+from django.views import View
 
 from .forms import AddressForm
 from .utils import get_property_data
 from urllib import urlencode
+
+from settings import MAPBOX_TOKEN
 
 from  .tfd_geocoder import getCoordinates
 
@@ -17,17 +21,21 @@ class AddressLookupView(FormView):
 
     def form_valid(self, form):
         form.clean_address()
-
         data = get_property_data(
             form.cleaned_data['street_no'], form.cleaned_data['street_dir'],
             form.cleaned_data['street_name'], form.cleaned_data['street_type'])
 
-
-        coordinates = getCoordinates(form.cleaned_data['address'])
-        import ipdb; ipdb.set_trace()
-
+        coords = getCoordinates(form.cleaned_data['address'])
         return self.render_to_response(
             self.get_context_data(
-                form=form, property=data, coordinates=coordinates
+                form=form, property=data, coordinates=coords,
+                MAPBOX_TOKEN=MAPBOX_TOKEN,
             )
         )
+
+# This view works but is not used
+class StreetMap (View):
+    def get(self, request, *args, **kwargs):
+        street_address=self.kwargs['address']
+        mapHTML = getSlippyMap(street_address)
+        return HttpResponse(mapHTML)


### PR DESCRIPTION
Changes:
1. Server side mapbox geolocation of submitted address
2. Mapbox map and satellite added to the form results
3. Added .env and .env-dist (we will need add this to heroku)

The 'slippy map' stuff is an attempt to add server side rendering of map html.  This could help with IE8 problems.  It is not used yet but I'd like to keep it just in case we need to used it.